### PR TITLE
Enable strong params, mass-whitelist for compatibility

### DIFF
--- a/app/controllers/account_sessions_controller.rb
+++ b/app/controllers/account_sessions_controller.rb
@@ -6,7 +6,7 @@ class AccountSessionsController < ApplicationController
   end
 
   def create
-    @session = AccountSession.new params[ :account_session]
+    @session = AccountSession.new unsafe_params[ :account_session]
     if @session.save
       session[:autofinger_level] = 1
       account = @session.record

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -6,7 +6,7 @@ class AccountsController < ApplicationController
   end
 
   def create
-    @account = params[:account]
+    @account = unsafe_params[:account]
     @username = @account['username']
     @user_email = "#{@account['username']}@#{@account['email_domain']}"
 
@@ -36,7 +36,7 @@ class AccountsController < ApplicationController
   end
 
   def confirm
-    token = params[:token]
+    token = unsafe_params[:token]
     ta = TentativeAccount.find_by_confirmation_token(token)
 
     if !ta || ta.created_at < (Time.now - 1.day)
@@ -55,7 +55,7 @@ class AccountsController < ApplicationController
   end
 
   def resend_confirmation_email
-    @username = params[:username]
+    @username = unsafe_params[:username]
     redirect_to action: 'new' unless @username
 
     ta = TentativeAccount.find_by_username(@username)

--- a/app/controllers/admin/secrets_controller.rb
+++ b/app/controllers/admin/secrets_controller.rb
@@ -2,12 +2,12 @@ class Admin::SecretsController < ApplicationController
   before_filter :require_admin, :load_autofingers
   # GET /admin/secrets
   def index
-    @secrets = Secret.page(params[:page]).order('date DESC')
+    @secrets = Secret.page(unsafe_params[:page]).order('date DESC')
   end
 
   def update
-    @secret = Secret.find(params[:id])
-    @secret.display_attr = params[:display_attr]
+    @secret = Secret.find(unsafe_params[:id])
+    @secret.display_attr = unsafe_params[:display_attr]
     if @secret.save
       render nothing: true
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,4 +29,12 @@ class ApplicationController < ActionController::Base
   def load_autofingers
     @autofingers = current_account.interests_in_others.updated.where priority: session[:autofinger_level]
   end
+
+  # Don't use this! It's for migration purposes only.
+  # Use strong unsafe_params properly instead:
+  # http://guides.rubyonrails.org/action_controller_overview.html#strong-parameters
+  def unsafe_params
+    ActiveSupport::Deprecation.warn("Using `unsafe_params` isn't a great plan", caller(1))
+    params.dup.tap(&:permit!)
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
   end
 
   def show
-    @page = params.fetch(:id, 'index')
+    @page = unsafe_params.fetch(:id, 'index')
     expanded_page = "#{Rails.root}/app/views/pages/#{@page}.haml"
     exists = File.exist?(File.expand_path(expanded_page))
     if exists

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -7,7 +7,7 @@ class PasswordResetsController < ApplicationController
   end
 
   def create
-    @account = Account.find_by_email(params[:email])
+    @account = Account.find_by_email(unsafe_params[:email])
     if @account
       @account.deliver_password_reset_instructions!
       flash[:notice] = 'Instructions to reset your password have been emailed to you. Please check your email.'
@@ -23,8 +23,8 @@ class PasswordResetsController < ApplicationController
   end
 
   def update
-    @account.password = params[:account][:password]
-    @account.password_confirmation = params[:account][:password_confirmation]
+    @account.password = unsafe_params[:account][:password]
+    @account.password_confirmation = unsafe_params[:account][:password_confirmation]
     if @account.save
       flash[:notice] = 'Password successfully updated'
       redirect_to root_path
@@ -36,7 +36,7 @@ class PasswordResetsController < ApplicationController
   private
 
   def load_account_using_perishable_token
-    @account = Account.find_using_perishable_token(params[:id])
+    @account = Account.find_using_perishable_token(unsafe_params[:id])
     unless @account
       flash[:notice] = "We're sorry, but we could not locate your account. " +
       'If you are having issues try copying and pasting the URL ' +

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -7,7 +7,7 @@ class PlansController < ApplicationController
 
   def update
     @plan = current_account.plan
-    @plan.edit_text = params[:plan][:edit_text]
+    @plan.edit_text = unsafe_params[:plan][:edit_text]
     if @plan.save
       redirect_to read_plan_path(id: @plan.account.username)
     else
@@ -16,7 +16,7 @@ class PlansController < ApplicationController
   end
 
   def show
-    username = params[:id] || current_account.username
+    username = unsafe_params[:id] || current_account.username
     @account = Account.find_by_username(username)
     if @account.blank?
       redirect_to action: :search, id: username
@@ -26,17 +26,17 @@ class PlansController < ApplicationController
   end
 
   def mark_level_as_read
-    Autofinger.mark_level_as_read(current_account.userid, params[:level])
-    redirect_to params[:return_to]
+    Autofinger.mark_level_as_read(current_account.userid, unsafe_params[:level])
+    redirect_to unsafe_params[:return_to]
   end
 
   def set_autofinger_level
-    session[:autofinger_level] = params[:level]
-    redirect_to params[:return_to]
+    session[:autofinger_level] = unsafe_params[:level]
+    redirect_to unsafe_params[:return_to]
   end
 
   def search
-    @account = Account.find_by_username(params[:id])
+    @account = Account.find_by_username(unsafe_params[:id])
     if !@account.blank?
       redirect_to read_plan_path(id: @account.username)
     else
@@ -46,14 +46,14 @@ class PlansController < ApplicationController
 
   def set_autofinger_subscription
     owner = current_account
-    interest = Account.find_by_username(params[:id])
+    interest = Account.find_by_username(unsafe_params[:id])
     autofinger = owner.interests_in_others.find_or_create_by(interest: interest.id)
-    success = autofinger.update_attributes(priority: params[:priority])
+    success = autofinger.update_attributes(priority: unsafe_params[:priority])
     if success
-      if params[:priority] == '0'
+      if unsafe_params[:priority] == '0'
         notice = 'User was removed from your autoread list.'
       else
-        notice = "User is now on your autoread list with priority level of #{params[:priority]}."
+        notice = "User is now on your autoread list with priority level of #{unsafe_params[:priority]}."
       end
     else
       notice = "Could not change autoread priority. If this happens more than once, contact the Plans admins at grinnellplans@gmail.com."

--- a/app/controllers/preferences/avail_links_controller.rb
+++ b/app/controllers/preferences/avail_links_controller.rb
@@ -8,7 +8,7 @@ module Preferences
     end
 
     def update
-      current_account.update params[:account]
+      current_account.update unsafe_params[:account]
       redirect_to preferences_links_path
     end
   end

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -3,7 +3,7 @@ class SecretsController < ApplicationController
 
   # GET /secrets
   def index
-    @secrets = Secret.where(display: 'yes').page(params[:page]).order('date DESC')
+    @secrets = Secret.where(display: 'yes').page(unsafe_params[:page]).order('date DESC')
     @secret = Secret.new
   end
 
@@ -14,7 +14,7 @@ class SecretsController < ApplicationController
 
   # POST /secrets
   def create
-    @secret = Secret.new(params[:secret])
+    @secret = Secret.new(unsafe_params[:secret])
     if @secret.save
       redirect_to(secrets_path, notice: 'Secret was successfully created.')
     else

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,9 +25,6 @@ module Plans
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = 'utf-8'
 
-    # This is naughty, but I swear I'll fix it later!
-    config.action_controller.permit_all_parameters = true
-
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
   end


### PR DESCRIPTION
[Strong params](http://guides.rubyonrails.org/action_controller_overview.html#strong-parameters) is great, but it's slow to upgrade an existing app and I don't want to slow down new work while we fill in the old stuff. So I put together this hack to give us a simpler migration path.

I've converted all the old controllers to use the descriptively-named `unsafe_params`, which bypasses the protection. As we fix controllers, we can remove those references. Meanwhile, new controllers can use regular `params` and do the normal strong params declarations to make those work.

Fixes #60.