### PR TITLE
Exclude a Rubocop rule in routes.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,8 @@ Style/FileName:
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
   Enabled: true
+  Exclude:
+    - 'config/routes.rb'
 
 Style/IndentationConsistency:
   Enabled: true


### PR DESCRIPTION
The hash syntax violations in the routes file don't bother me (since it's its own little DSL). So excluding that file from that particular check.