### PR TITLE
Add viewport meta tag to allow for future responsive stylesheets

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,6 +3,7 @@
   %head
     %meta{"http-equiv"=>"Content-Type", :content=>"text/html", :charset=>"utf-8"}
     %meta{:name=>"ROBOTS", :content=>"noarchhive"}
+    %meta{:name=>"viewport", :content=>"width=device-width, initial-scale=1"}
     - if content_for?(:title)
       %title
         = content_for(:title)


### PR DESCRIPTION
Fixes #86 – libre.css still looks good with this change, as far as I can tell.