### PR TITLE
Add row height and 100% width to textarea used to edit plan

### DIFF
--- a/app/assets/stylesheets/libre.css
+++ b/app/assets/stylesheets/libre.css
@@ -401,6 +401,10 @@ p.sub:first-letter {
 	color: #888;
 }
 
+#plan_edit_text {
+	width: 100%;
+}
+
 /* Space out secret headers a bit */
 .secret .secret_id {
 	margin-right: 1em;

--- a/app/views/plans/edit.html.haml
+++ b/app/views/plans/edit.html.haml
@@ -3,7 +3,7 @@
 
 #editform
   =form_for @plan, :url => {:action=>:update, :controller=>:plans } do |f|
-    =f.text_area :edit_text, :onkeyup=>"javascript:checkPlanLength()"
+    =f.text_area :edit_text, :rows=>"14", :onkeyup=>"javascript:checkPlanLength()"
     %br
     #edit_fill_meter
       .fill_bar


### PR DESCRIPTION
Fixes #83 - it's not responsive, but the default libre.css `#main` div is sized to a reasonable 40em so I thought the best thing to do is just line the `textarea` up with the rest of the main content by giving it `width: 100%;`.

I could go further and rework the way the parent containers are sized to make them percentage-based, but that may be better for a more lengthy/in depth issue and pull (maybe #92).