### PR TITLE
BoardVote#vote only accepts -1 or 1 (or blanks)

### DIFF
--- a/app/models/board_vote.rb
+++ b/app/models/board_vote.rb
@@ -5,6 +5,7 @@ class BoardVote < ActiveRecord::Base
   belongs_to :main_board, foreign_key: :threadid
   belongs_to :sub_board, foreign_key: :messageid
   validates_presence_of :main_board, :sub_board, :account, :vote_date
+  validates_inclusion_of :vote, :in => [-1, 1], :allow_blank => true
 
   before_update :set_vote_date
 

--- a/spec/models/board_vote_spec.rb
+++ b/spec/models/board_vote_spec.rb
@@ -22,6 +22,15 @@ describe BoardVote do
     @board_vote.sub_board = nil
     expect(@board_vote).not_to be_valid
   end
+
+  it 'is only valid with a -1 or 1 vote' do
+    @board_vote.vote = 1
+    expect(@board_vote).to be_valid
+    @board_vote.vote = -1
+    expect(@board_vote).to be_valid
+    @board_vote.vote = 42
+    expect(@board_vote).not_to be_valid
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
BoardVote#vote now validates for either a -1 or 1 value. Also added `:allow_blank` so that a BoardVote can be instantiated and valid without setting the vote (ie. letting it be non-null), which prevents the `is valid with valid attributes` test from immediately failing. I wasn't sure what the difference is between `:allow_blank` and `:allow_null` when not involving strings, so that can be changed if it's incorrect.

Also added a new `is only valid with a -1 or 1 vote` test which confirms that the rule works.