### PR TITLE
fixed the helper for Planwatch

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Plans::Application.routes.draw do
       get :set_autofinger_level
       put :mark_level_as_read
       get :search, as: 'search'
-      get :planwatch, as: :recently_updated
+      get :planwatch
     end
     member do
       get :edit


### PR DESCRIPTION
I think at some point in the merging this old route definition for Planwatch stuck around, causing an `undefined method` error relating to the route helper.