### PR TITLE
Blocking (for plans, planwatch, preferences, and index/about)

### DIFF
--- a/app/controllers/block_controller.rb
+++ b/app/controllers/block_controller.rb
@@ -5,7 +5,10 @@ class BlockController < ApplicationController
     blocked = params[:target]
     blocking = current_account.userid
     Block.find_or_create_by(blocking_userid: blocking, blocked_userid: blocked)
-    redirect_to :back
+    redirect_to :back, notice: "You have blocked this user. Blocking a user is one-directional."\
+    " Selecting \"Block\" renders the contents of your plan unavailable to this user."\
+    " Neither will see any [planlove] by the other, and any updates either make will not show up on each other’s planwatch."\
+    "\nIf this block was made in error, please use the option at the bottom of the page to un-do."
   end
 
   def destroy
@@ -15,6 +18,6 @@ class BlockController < ApplicationController
     unless b.nil?
       b.destroy
     end
-    redirect_to :back
+    redirect_to :back, notice: "User #{Account.find_by(userid: blocked).username} has been unblocked."
   end
 end

--- a/app/controllers/block_controller.rb
+++ b/app/controllers/block_controller.rb
@@ -1,0 +1,20 @@
+class BlockController < ApplicationController
+  before_filter :require_user
+
+  def create
+    blocked = params[:target]
+    blocking = current_account.userid
+    Block.find_or_create_by(blocking_userid: blocking, blocked_userid: blocked)
+    redirect_to :back
+  end
+
+  def destroy
+    blocked = params[:target]
+    blocking = current_account.userid
+    b = Block.find_by(blocking_userid: blocking, blocked_userid: blocked)
+    unless b.nil?
+      b.destroy
+    end
+    redirect_to :back
+  end
+end

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -1,4 +1,4 @@
-class BlockController < ApplicationController
+class BlocksController < ApplicationController
   before_filter :require_user
 
   def create

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -20,4 +20,9 @@ class BlocksController < ApplicationController
     end
     redirect_to :back, notice: "User #{Account.find_by(userid: blocked).username} has been unblocked."
   end
+
+  def index
+    @account = Account.find_by_username(current_account.username)
+    @blocks = Block.where(blocking_userid: current_account.userid)
+  end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -22,6 +22,13 @@ class PlansController < ApplicationController
     if @account.blank?
       redirect_to action: :search, id: username
     else
+      @plantext = if Block.where(blocking_userid: @account.userid)
+                          .where(blocked_userid: current_account.userid)
+                          .empty?
+        @account.plan.generated_html
+      else
+        "[#{@account.username}] has enabled the block feature. This plan is not available."
+      end
       @viewing_self = username == current_account.username
       @block = Block.where(blocking_userid: current_account.userid)
                     .where(blocked_userid: @account.userid)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/try'
+
 class PlansController < ApplicationController
   def edit
     @plan = current_account.plan
@@ -20,6 +22,10 @@ class PlansController < ApplicationController
     if @account.blank?
       redirect_to action: :search, id: username
     else
+      @viewing_self = username == current_account.username
+      @block = Block.where(blocking_userid: current_account.userid)
+                    .where(blocked_userid: @account.userid)
+                    .first
       Autofinger.mark_plan_as_read(current_account.userid, @account.userid)
     end
   end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -58,7 +58,11 @@ class PlansController < ApplicationController
 
   def planwatch
     @hours = if params[:hours].to_i < 1 then 12 else params[:hours].to_i end
-    @plans = Account.where(changed: (Time.now - @hours.hours)..Time.now).order(changed: :desc)
+    blocks = (Block.where(blocking_userid: current_account.userid).pluck(:blocked_userid) +
+              Block.where(blocked_userid: current_account.userid).pluck(:blocking_userid)).uniq
+    @plans = Account.where(changed: (Time.now - @hours.hours)..Time.now)
+                    .order(changed: :desc)
+                    .where.not(userid: blocks)
   end
 
   def set_autofinger_subscription

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -44,7 +44,7 @@ class PlansController < ApplicationController
   end
 
   def planwatch
-    @hours = params[:hours].to_i rescue 12
+    @hours = if params[:hours].to_i < 1 then 12 else params[:hours].to_i end
     @plans = Account.where(changed: (Time.now - @hours.hours)..Time.now).order(changed: :desc)
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -23,8 +23,8 @@ class Account < ActiveRecord::Base
   has_many :sub_boards, foreign_key: :userid
   has_one :viewed_secret, foreign_key: :userid, dependent: :destroy
   has_one :plan, foreign_key: :user_id, dependent: :destroy
-  has_many :source_blocks, source: :blocks, foreign_key: :blocking_userid
-  has_many :target_blocks, source: :blocks, foreign_key: :blocked_userid
+  has_many :source_blocks, class_name: "Block", foreign_key: :blocking_userid
+  has_many :target_blocks, class_name: "Block", foreign_key: :blocked_userid
 
   has_one :display_preference, foreign_key: :userid, dependent: :destroy
   has_one :custom_stylesheet, foreign_key: :userid, dependent: :destroy

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -23,6 +23,8 @@ class Account < ActiveRecord::Base
   has_many :sub_boards, foreign_key: :userid
   has_one :viewed_secret, foreign_key: :userid, dependent: :destroy
   has_one :plan, foreign_key: :user_id, dependent: :destroy
+  has_many :source_blocks, source: :blocks, foreign_key: :blocking_userid
+  has_many :target_blocks, source: :blocks, foreign_key: :blocked_userid
 
   has_one :display_preference, foreign_key: :userid, dependent: :destroy
   has_one :custom_stylesheet, foreign_key: :userid, dependent: :destroy

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -1,0 +1,4 @@
+class Block < ActiveRecord::Base
+  belongs_to :account, foreign_key: :blocked_userid
+  belongs_to :account, foreign_key: :blocking_userid
+end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -1,4 +1,4 @@
 class Block < ActiveRecord::Base
-  belongs_to :account, foreign_key: :blocked_userid
-  belongs_to :account, foreign_key: :blocking_userid
+  belongs_to :blocked_user, class_name: "Account", foreign_key: :blocked_userid
+  belongs_to :blocking_user, class_name: "Account", foreign_key: :blocking_userid
 end

--- a/app/views/blocks/index.html.haml
+++ b/app/views/blocks/index.html.haml
@@ -1,0 +1,12 @@
+%p.info_message Users that you have blocked will not be able to read your plan, and you will not see each other listed in quicklove or search results.
+= link_to "See the FAQ for more information", about_blocks_path
+%p
+  %b Please be aware that your activity on Notes is still visible to everyone.
+  If you feel this presents a serious problem to you, please
+  %a{ href: "mailto:grinnellplans@gmail.com" } contact the administrators.
+%h2 Blocked Users
+- @blocks.each do |b|
+  = link_to "[#{b.blocked_user.username}]", read_plan_path(id: b.blocked_user.username)
+  = form_tag b, method: :delete do
+    = hidden_field_tag 'target', b.blocked_user.userid
+    = submit_tag "Unblock #{b.blocked_user.username}"

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -43,3 +43,15 @@
     = radio_button_tag :priority, 3
     = label_tag 'priority_3', 3
     = submit_tag 'Save'
+
+- if !@viewing_self
+  - if @block
+    .block-control
+      = form_tag @block, method: :delete do
+        = hidden_field_tag 'target', @account.userid
+        = submit_tag 'Unblock this user'
+  - else
+    .block-control
+      = form_tag block_index_path, method: :post do
+        = hidden_field_tag 'target', @account.userid
+        = submit_tag 'Block this user'

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -52,6 +52,6 @@
         = submit_tag 'Unblock this user'
   - else
     .block-control
-      = form_tag block_index_path, method: :post do
+      = form_tag blocks_index_path, method: :post do
         = hidden_field_tag 'target', @account.userid
         = submit_tag 'Block this user'

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -30,7 +30,7 @@
           =@account.pseudo
 
 .plan_text
-  =@account.plan.generated_html
+  = @plantext
 
 .autofinger-control
   = form_tag set_autofinger_subscription_plan_path, method: :put do

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -52,6 +52,6 @@
         = submit_tag 'Unblock this user'
   - else
     .block-control
-      = form_tag blocks_index_path, method: :post do
+      = form_tag blocks_path, method: :post do
         = hidden_field_tag 'target', @account.userid
         = submit_tag 'Block this user'

--- a/app/views/preferences/index.html.haml
+++ b/app/views/preferences/index.html.haml
@@ -3,6 +3,6 @@
   - each_with_list_classes %w[account display] do |section, classes|
     %li{ class: classes }
       = link_to t("links.#{section}"), dynamic_link_helper("preferences_#{section}_path"), class: "preflink"
-  - each_with_list_classes %w[block] do |section, classes|
+  - each_with_list_classes %w[blocks] do |section, classes|
     %li{ class: classes }
       = link_to t("links.#{section}"), dynamic_link_helper("#{section}_index_path"), class: "preflink"

--- a/app/views/preferences/index.html.haml
+++ b/app/views/preferences/index.html.haml
@@ -3,3 +3,6 @@
   - each_with_list_classes %w[account display] do |section, classes|
     %li{ class: classes }
       = link_to t("links.#{section}"), dynamic_link_helper("preferences_#{section}_path"), class: "preflink"
+  - each_with_list_classes %w[block] do |section, classes|
+    %li{ class: classes }
+      = link_to t("links.#{section}"), dynamic_link_helper("#{section}_index_path"), class: "preflink"

--- a/app/views/preferences/index.html.haml
+++ b/app/views/preferences/index.html.haml
@@ -5,4 +5,4 @@
       = link_to t("links.#{section}"), dynamic_link_helper("preferences_#{section}_path"), class: "preflink"
   - each_with_list_classes %w[blocks] do |section, classes|
     %li{ class: classes }
-      = link_to t("links.#{section}"), dynamic_link_helper("#{section}_index_path"), class: "preflink"
+      = link_to t("links.#{section}"), dynamic_link_helper("#{section}_path"), class: "preflink"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
   links:
     account: Account Information
     display: Customize Your Page
-    block: Blocking
+    blocks: Blocking
   date:
     formats:
       default: "%m/%d/%Y %H:%M"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
   links:
     account: Account Information
     display: Customize Your Page
+    block: Blocking
   date:
     formats:
       default: "%m/%d/%Y %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Plans::Application.routes.draw do
       get :set_autofinger_level
       put :mark_level_as_read
       get :search, as: 'search'
-      get :planwatch, as: :recently_updated
+      get :planwatch
     end
     member do
       get :edit
@@ -54,6 +54,10 @@ Plans::Application.routes.draw do
   end
 
   resources :password_resets, except: [:destroy, :show, :index]
+
+  resources :block, only: [:index, :create, :destroy] do
+    get :about, on: :collection
+  end
 
   get '/register' => 'accounts#new', :as => :register
   get '/login' => 'account_sessions#new', :as => :login

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Plans::Application.routes.draw do
 
   resources :password_resets, except: [:destroy, :show, :index]
 
-  resources :block, only: [:index, :create, :destroy] do
+  resources :blocks, only: [:index, :create, :destroy] do
     get :about, on: :collection
   end
 

--- a/db/migrate/20160305220019_create_blocks.rb
+++ b/db/migrate/20160305220019_create_blocks.rb
@@ -1,0 +1,12 @@
+class CreateBlocks < ActiveRecord::Migration
+  def change
+    create_table "blocks", primary_key: "blockid", force: :cascade do |t|
+      t.integer "blocked_userid",  limit: 2, default: 0, null: false
+      t.integer "blocking_userid", limit: 2, default: 0, null: false
+    end
+
+    add_index "blocks", ["blocked_userid", "blocking_userid"], name: "pair", unique: true
+    add_index "blocks", ["blocked_userid"], name: "blocked"
+    add_index "blocks", ["blocking_userid"], name: "blocking"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160130033929) do
+ActiveRecord::Schema.define(version: 20160305220019) do
 
   create_table "accounts", primary_key: "userid", force: :cascade do |t|
     t.string   "username",             limit: 16,  default: "",               null: false
@@ -66,6 +66,15 @@ ActiveRecord::Schema.define(version: 20160130033929) do
     t.text   "static",       limit: 255
     t.string "rails_helper"
   end
+
+  create_table "blocks", primary_key: "blockid", force: :cascade do |t|
+    t.integer "blocked_userid",  limit: 2, default: 0, null: false
+    t.integer "blocking_userid", limit: 2, default: 0, null: false
+  end
+
+  add_index "blocks", ["blocked_userid", "blocking_userid"], name: "pair", unique: true
+  add_index "blocks", ["blocked_userid"], name: "blocked"
+  add_index "blocks", ["blocking_userid"], name: "blocking"
 
   create_table "boardvotes", primary_key: "voteid", force: :cascade do |t|
     t.integer  "userid",    limit: 2, default: 0, null: false


### PR DESCRIPTION
Blocking is now implemented for viewing plans, getting results on Planwatch, the preferences page, and index/about pages. It is not implemented for the following since they have not been done yet:

* search
* planlove
* "Did you read [xyz], who just updated?" message

As it's not technically fully implemented, I'm not sure if the issue should be left opened or if new sub-issues should be created.

I put all changes to blocks (create and destroy) under blocks resources rather than, for example, plans/read having a form that goes to itself and then interacting with the database directly.

I'm pretty sure I used the path helpers correctly, but that should be double checked to make sure it's inline with how the rest of the app is designed.