### PR TITLE
Plans genesis (fixes #66)

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -49,8 +49,8 @@ class PlansController < ApplicationController
   end
 
   def genesis
-    @days = if params[:days].to_i < 1 then 12 else params[:days].to_i end
-    @plans = Account.where(created: (Time.now - @hours.days)..Time.now).order(created: :desc)
+    @days = if params[:days].to_i < 1 then 5 else params[:days].to_i end
+    @plans = Account.where(created: (Time.now - @days.days)..Time.now).order(created: :desc)
   end
 
   def set_autofinger_subscription

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -48,6 +48,11 @@ class PlansController < ApplicationController
     @plans = Account.where(changed: (Time.now - @hours.hours)..Time.now).order(changed: :desc)
   end
 
+  def genesis
+    @days = if params[:days].to_i < 1 then 12 else params[:days].to_i end
+    @plans = Account.where(created: (Time.now - @hours.days)..Time.now).order(created: :desc)
+  end
+
   def set_autofinger_subscription
     owner = current_account
     interest = Account.find_by_username(unsafe_params[:id])

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -60,6 +60,14 @@ class Account < ActiveRecord::Base
     self[:changed]
   end
 
+  def created_date=(value)
+    self[:created] = value
+  end
+
+  def created_date
+    self[:created]
+  end
+
   # def grad_year_for_user_type
   #    (user_type == 'student' && grad_year > 0) || user_type != 'student'
   #  end

--- a/app/views/plans/genesis.html.haml
+++ b/app/views/plans/genesis.html.haml
@@ -1,0 +1,9 @@
+= form_tag({}, method: "get") do
+  = label_tag "days", "Plans updated in the past:"
+  = number_field_tag "days", @days, min: 1, max: 100
+  = label_tag "days", "days"
+%ul
+  - @plans.each do |p|
+    %li
+      = link_to p.username, p.username
+      = p.created_date.strftime "%k:%M %p, %a %B %e"

--- a/app/views/plans/genesis.html.haml
+++ b/app/views/plans/genesis.html.haml
@@ -1,5 +1,5 @@
 = form_tag({}, method: "get") do
-  = label_tag "days", "Plans updated in the past:"
+  = label_tag "days", "Plans created in the past:"
   = number_field_tag "days", @days, min: 1, max: 100
   = label_tag "days", "days"
 %ul

--- a/app/views/plans/planwatch.html.haml
+++ b/app/views/plans/planwatch.html.haml
@@ -1,5 +1,5 @@
 = form_tag({}, method: "get") do
-  = label_tag "hours", "Plans created in the past:"
+  = label_tag "hours", "Plans updated in the past:"
   = number_field_tag "hours", @hours, min: 1, max: 100
   = label_tag "hours", "hours"
 %ul

--- a/app/views/plans/planwatch.html.haml
+++ b/app/views/plans/planwatch.html.haml
@@ -1,5 +1,5 @@
 = form_tag({}, method: "get") do
-  = label_tag "hours", "Plans updated in the past:"
+  = label_tag "hours", "Plans created in the past:"
   = number_field_tag "hours", @hours, min: 1, max: 100
   = label_tag "hours", "hours"
 %ul

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Plans::Application.routes.draw do
       put :mark_level_as_read
       get :search, as: 'search'
       get :planwatch, as: :recently_updated
+      get :genesis, as: :recently_created_plans
     end
     member do
       get :edit
@@ -81,7 +82,6 @@ Plans::Application.routes.draw do
   get "/" => "plans#show", as: :quicklove
   get "/" => "plans#show", as: :polls
   get "/" => "plans#show", as: :random_plan
-  get "/" => "plans#show", as: :recently_created_plans
 
   # adding default route as lowest priority
   # match '/:controller(/:action(/:id))'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Plans::Application.routes.draw do
       put :mark_level_as_read
       get :search, as: 'search'
       get :planwatch, as: :recently_updated
-      get :genesis, as: :recently_created_plans
+      get :genesis, as: :recently_created
     end
     member do
       get :edit


### PR DESCRIPTION
Similar to the Planwatch route, I placed Plans Genesis under the collections routes for the Plans resource. This one is simply at `plans/genesis`.