### PR TITLE
Remove weird default in plans#show

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -15,7 +15,7 @@ class PlansController < ApplicationController
   end
 
   def show
-    username = unsafe_params[:id] || current_account.username
+    username = params[:id]
     @account = Account.find_by_username(username)
     if @account.blank?
       redirect_to action: :search, id: username


### PR DESCRIPTION
I came across a strange bit of cruft in the plans controller setting a default if no plans name is given. It doesn't seem like this is used anywhere, so I'm guessing it's leftover from an early version.