### PR TITLE
Include debugger in test as well

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,9 +63,6 @@ group :development do
   gem 'web-console'
 
   gem 'thin'
-
-  # Debugger
-  gem 'byebug'
 end
 
 group :test, :development do
@@ -77,6 +74,9 @@ group :test, :development do
 
   # Automated checking of code style and correctness
   gem 'rubocop'
+
+  # Debugger
+  gem 'byebug'
 end
 
 group :test do


### PR DESCRIPTION
Simply moving a gem into more groups. This way debugging is available in the specs as well as in development.