### PR TITLE
Style: make suggested rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - '**/Capfile'
   Exclude:
     - 'vendor/**/*'
+    - 'db/migrate/*'
     - 'db/schema.rb'
     - 'app/views/forem'
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "foreman"
 gem "administrate", "~> 0.1.4"
 
 # Forum gem to replace notes
-gem 'forem', :github => "radar/forem", :branch => "rails4"
+gem 'forem', github: "radar/forem", branch: "rails4"
 
 group :production do
   #email any errors to people specified in the environment.rb

--- a/app/models/board_vote.rb
+++ b/app/models/board_vote.rb
@@ -5,7 +5,7 @@ class BoardVote < ActiveRecord::Base
   belongs_to :main_board, foreign_key: :threadid
   belongs_to :sub_board, foreign_key: :messageid
   validates_presence_of :main_board, :sub_board, :account, :vote_date
-  validates_inclusion_of :vote, :in => [-1, 1], :allow_blank => true
+  validates_inclusion_of :vote, in: [-1, 1], allow_blank: true
 
   before_update :set_vote_date
 


### PR DESCRIPTION
Something easy as I get back into the code... 
Ignore the db/migrate dir for rubocop, because it's not cool to go back and alter migrations and the default generator uses hashrockets.