### PR TITLE
Add Docker configurations and instructions for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.2
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  nodejs
+
+RUN mkdir -p /code
+WORKDIR /code
+
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler && bundle install --jobs 20 --retry 5
+
+EXPOSE 3000
+
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+
+    plans:
+        build: .
+        ports:
+            - 3000:3000
+        volumes:
+            - ./:/code
+        command: bundle exec rails server -b 0.0.0.0

--- a/local-development-using-docker.md
+++ b/local-development-using-docker.md
@@ -1,0 +1,31 @@
+## Local development using Docker
+
+### First run:
+
+1. [Install Docker](https://www.docker.com/products/docker)
+2. Build the image:
+    ```bash
+    docker-compose build
+    ```
+    This will build the docker image defined in the Dockerfile. It can take a while to pull images and run the installation steps, but you shouldn't have to repeat this step unless you delete the image.
+
+2. Create and seed the database:
+    ```bash
+    docker-compose run plans rake db:setup
+    ```
+    At this point, you're ready to run the development server, tests, or the console as described below.
+
+### Subsequent runs:
+
+- Run the development server:
+    ```bash
+    docker-compose up
+    ```
+- Run tests:
+    ```bash
+    docker-compose run plans ./bin/rspec spec
+    ```
+- Run a Rails console:
+    ```bash
+    docker-compose run plans ./bin/rails console
+    ```

--- a/local-development-using-docker.md
+++ b/local-development-using-docker.md
@@ -18,14 +18,14 @@
 ### Subsequent runs:
 
 - Run the development server:
-    ```bash
-    docker-compose up
-    ```
+```bash
+docker-compose up
+```
 - Run tests:
-    ```bash
-    docker-compose run plans ./bin/rspec spec
-    ```
+```bash
+docker-compose run plans ./bin/rspec spec
+```
 - Run a Rails console:
-    ```bash
-    docker-compose run plans ./bin/rails console
-    ```
+```bash
+docker-compose run plans ./bin/rails console
+```


### PR DESCRIPTION
To run the server locally using docker, simply run `docker-compose up`. If you already have a sqlite database, you shouldn't have to run any migrations first. Otherwise, follow "First run" instructions in the instructions at local-development-using-docker.md.